### PR TITLE
fix(cmd/ls): ls api does not return links hash instead of input hash

### DIFF
--- a/src/main/java/io/ipfs/api/IPFS.java
+++ b/src/main/java/io/ipfs/api/IPFS.java
@@ -102,7 +102,9 @@ public class IPFS {
 
     public List<MerkleNode> ls(Multihash hash) throws IOException {
         Map res = retrieveMap("ls?arg=" + hash);
-        return ((List<Object>) res.get("Objects")).stream().map(x -> MerkleNode.fromJSON((Map) x)).collect(Collectors.toList());
+        Map res0 = (Map) ((List<Object>) res.get("Objects")).get(0);
+        List<Object> links = (List<Object>) res0.get("Links");
+        return links.stream().map(x -> MerkleNode.fromJSON((Map) x)).collect(Collectors.toList());
     }
 
     public byte[] cat(Multihash hash) throws IOException {


### PR DESCRIPTION
refs: #112 

License: MIT
Signed-off-by: chenminjian <727180553@qq.com>