### PR TITLE
SecureRandom used instead of Random.

### DIFF
--- a/src/main/java/io/ipfs/api/Multipart.java
+++ b/src/main/java/io/ipfs/api/Multipart.java
@@ -3,6 +3,7 @@ package io.ipfs.api;
 import java.io.*;
 import java.net.*;
 import java.nio.file.*;
+import java.security.SecureRandom;
 import java.util.*;
 
 public class Multipart {
@@ -33,7 +34,7 @@ public class Multipart {
     }
 
     public static String createBoundary() {
-        Random r = new Random();
+        SecureRandom r = new SecureRandom();
         String allowed = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
         StringBuilder b = new StringBuilder();
         for (int i=0; i < 32; i++)


### PR DESCRIPTION
As the java.util.Random class relies on a pseudorandom number generator, this class and relating java.lang.Math.random() method should not be used for security-critical applications or for protecting sensitive data. In such context, the java.security.SecureRandom class which relies on a cryptographically strong random number generator (RNG) should be used in place.