### PR TITLE
Implement HTTP client side timeout

### DIFF
--- a/src/main/java/io/ipfs/api/IPFS.java
+++ b/src/main/java/io/ipfs/api/IPFS.java
@@ -18,11 +18,13 @@ public class IPFS {
     public enum PinType {all, direct, indirect, recursive}
     public List<String> ObjectTemplates = Arrays.asList("unixfs-dir");
     public List<String> ObjectPatchTypes = Arrays.asList("add-link", "rm-link", "set-data", "append-data");
+    private static final int DEFAULT_TIMEOUT = 0;
 
     public final String host;
     public final int port;
     public final String protocol;
     private final String version;
+    private int timeout = DEFAULT_TIMEOUT;
     public final Key key = new Key();
     public final Pin pin = new Pin();
     public final Repo repo = new Repo();
@@ -72,6 +74,17 @@ public class IPFS {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+    
+    /**
+     * Configure a HTTP client timeout
+     * @param timeout (default 0: infinite timeout)
+     * @return current IPFS object with configured timeout
+     */
+    public IPFS timeout(int timeout) {
+        if(timeout < 0) throw new IllegalArgumentException("timeout must be zero or positive");
+        this.timeout = timeout;
+        return this;
     }
 
     public List<MerkleNode> add(NamedStreamable file) throws IOException {
@@ -659,13 +672,11 @@ public class IPFS {
 
     private byte[] retrieve(String path) throws IOException {
         URL target = new URL(protocol, host, port, version + path);
-        return IPFS.get(target);
+        return IPFS.get(target, timeout);
     }
 
-    private static byte[] get(URL target) throws IOException {
-        HttpURLConnection conn = (HttpURLConnection) target.openConnection();
-        conn.setRequestMethod("GET");
-        conn.setRequestProperty("Content-Type", "application/json");
+    private static byte[] get(URL target, int timeout) throws IOException {
+        HttpURLConnection conn = configureConnection(target, "GET", timeout);
 
         try {
             InputStream in = conn.getInputStream();
@@ -678,6 +689,8 @@ public class IPFS {
             return resp.toByteArray();
         } catch (ConnectException e) {
             throw new RuntimeException("Couldn't connect to IPFS daemon at "+target+"\n Is IPFS running?");
+        } catch (SocketTimeoutException e) {
+            throw new RuntimeException(String.format("timeout (%d ms) has been exceeded", timeout));
         } catch (IOException e) {
             String err = new String(readFully(conn.getErrorStream()));
             throw new RuntimeException("IOException contacting IPFS daemon.\nTrailer: " + conn.getHeaderFields().get("Trailer") + " " + err, e);
@@ -725,28 +738,24 @@ public class IPFS {
 
     private InputStream retrieveStream(String path) throws IOException {
         URL target = new URL("http", host, port, version + path);
-        return IPFS.getStream(target);
+        return IPFS.getStream(target, timeout);
     }
 
-    private static InputStream getStream(URL target) throws IOException {
-        HttpURLConnection conn = (HttpURLConnection) target.openConnection();
-        conn.setRequestMethod("GET");
-        conn.setRequestProperty("Content-Type", "application/json");
+    private static InputStream getStream(URL target, int timeout) throws IOException {
+        HttpURLConnection conn = configureConnection(target, "GET", timeout);
         return conn.getInputStream();
     }
 
     private Map postMap(String path, byte[] body, Map<String, String> headers) throws IOException {
         URL target = new URL(protocol, host, port, version + path);
-        return (Map) JSONParser.parse(new String(post(target, body, headers)));
+        return (Map) JSONParser.parse(new String(post(target, body, headers, timeout)));
     }
 
-    private static byte[] post(URL target, byte[] body, Map<String, String> headers) throws IOException {
-        HttpURLConnection conn = (HttpURLConnection) target.openConnection();
+    private static byte[] post(URL target, byte[] body, Map<String, String> headers, int timeout) throws IOException {
+        HttpURLConnection conn = configureConnection(target, "POST", timeout);
         for (String key: headers.keySet())
             conn.setRequestProperty(key, headers.get(key));
         conn.setDoOutput(true);
-        conn.setRequestMethod("POST");
-        conn.setRequestProperty("Content-Type", "application/json");
         OutputStream out = conn.getOutputStream();
         out.write(body);
         out.flush();
@@ -767,5 +776,13 @@ public class IPFS {
 
     private static boolean detectSSL(MultiAddress multiaddress) {
         return multiaddress.toString().contains("/https");
+    }
+    
+    private static HttpURLConnection configureConnection(URL target, String method, int timeout) throws IOException {
+        HttpURLConnection conn = (HttpURLConnection) target.openConnection();
+        conn.setRequestMethod(method);
+        conn.setRequestProperty("Content-Type", "application/json");
+        conn.setReadTimeout(timeout);
+        return conn;
     }
 }

--- a/src/test/java/io/ipfs/api/APITest.java
+++ b/src/test/java/io/ipfs/api/APITest.java
@@ -720,6 +720,18 @@ public class APITest {
         Map commands = ipfs.commands();
     }
 
+    @Test(expected = RuntimeException.class)
+    public void testTimeoutFail() throws IOException {
+        IPFS ipfs = new IPFS(new MultiAddress("/ip4/127.0.0.1/tcp/5001")).timeout(1000);
+        ipfs.cat(Multihash.fromBase58("QmYpbSXyiCTYCbyMpzrQNix72nBYB8WRv6i39JqRc8C1ry"));
+    }
+
+    @Test
+    public void testTimeoutOK() throws IOException {
+        IPFS ipfs = new IPFS(new MultiAddress("/ip4/127.0.0.1/tcp/5001")).timeout(1000);
+        ipfs.cat(Multihash.fromBase58("Qmaisz6NMhDB51cCvNWa1GMS7LU1pAxdF4Ld6Ft9kZEP2a"));
+    }
+
     // this api is disabled until deployment over IPFS is enabled
     public void updateTest() throws IOException {
         Object check = ipfs.update.check();


### PR DESCRIPTION
The purpose of this feature is to implement an optional HTTP client side timeout using `HttpURLConnection.setReadTimeout(int timeout)` because the API Server doesn't provide any timeout mechanism and when **java-ipfs-http-client** does `IPFS.cat(multihash)` but the hash cannot be found on the IPFS network, the call hangs forever (or until found).
This is usually quite risky and bad practice for a client to block threads like that.

So the idea is to configure a timeout (in ms) to prevent this:
- `timeout` is set by default to 0 (infinite timeout) to avoid compatibility issues 
- `timeout` can be configured like this:

```java
IPFS ipfs = new IPFS(new MultiAddress("/ip4/127.0.0.1/tcp/5001")).timeout(1000)
```

